### PR TITLE
Add warning on `env` option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -206,6 +206,11 @@ module.exports = {
 }
 ```
 
+<p class="warning">
+  If you already set your own `NODE_ENV` environment variable, Poi will not define your `process.env.NODE_ENV`.
+  `process.env.NODE_ENV` will retain the original value.
+</p>
+
 ### format
 
 Type: `string`<br>


### PR DESCRIPTION
Add warning about [`env`](https://poi.js.org/#/options?id=env) option.

https://github.com/egoist/poi/blob/7506e5bd200b7ebb38efcccd5ffd8b8399d8443c/packages/poi/lib/index.js#L52-L66

You can edit words if it isn't good enough.